### PR TITLE
HPE MCP repository: Fix jessie/stretch packages, allow setting repository version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,1 +1,4 @@
 ---
+
+hwraid_hp_repository_version: 'current'
+

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -17,8 +17,8 @@ hwraid_apt_le_vert_repository: 'deb http://hwraid.le-vert.net/{{ ansible_distrib
 
 # HP raid controller tools
 hwraid_hp_raid_packages:
-  - hpacucli
-  - hpssacli
+  - ssa
+  - ssacli
   - nagios-plugins-contrib
 
 # IBM raid controller tools

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -10,7 +10,7 @@ hwraid_apt_le_vert_keys:
   - http://hwraid.le-vert.net/debian/hwraid.le-vert.net.gpg.key
 
 # HP apt repository
-hwraid_apt_hp_repository: 'deb http://downloads.linux.hpe.com/SDR/repo/mcp/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }}/current non-free'
+hwraid_apt_hp_repository: 'deb http://downloads.linux.hpe.com/SDR/repo/mcp/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }}/{{ hwraid_hp_repository_version }}'
 
 # hwraid.le-vert.net apt repository
 hwraid_apt_le_vert_repository: 'deb http://hwraid.le-vert.net/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }} main'
@@ -19,6 +19,7 @@ hwraid_apt_le_vert_repository: 'deb http://hwraid.le-vert.net/{{ ansible_distrib
 hwraid_hp_raid_packages:
   - ssa
   - ssacli
+  - ssaducli
   - nagios-plugins-contrib
 
 # IBM raid controller tools

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -10,7 +10,7 @@ hwraid_apt_le_vert_keys:
   - http://hwraid.le-vert.net/debian/hwraid.le-vert.net.gpg.key
 
 # HP apt repository
-hwraid_apt_hp_repository: 'deb http://downloads.linux.hpe.com/SDR/repo/mcp/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }}/{{ hwraid_hp_repository_version }}'
+hwraid_apt_hp_repository: 'deb http://downloads.linux.hpe.com/SDR/repo/mcp/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }}/{{ hwraid_hp_repository_version }} non-free'
 
 # hwraid.le-vert.net apt repository
 hwraid_apt_le_vert_repository: 'deb http://hwraid.le-vert.net/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }} main'

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -12,9 +12,9 @@ hwraid_yum_hp_repository:
 
 # HP raid controller tools
 hwraid_hp_raid_packages:
-  - ssaducli
-  - ssacli
   - ssa
+  - ssacli
+  - ssaducli
 
 # IBM raid controller tools
 hwraid_ibm_raid_packages: []

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -5,7 +5,7 @@ hwraid_yum_hp_repository:
   name: hpe
   file: HPE
   description: CentOS-$releasever - HP Raid Controller
-  baseurl: http://downloads.linux.hpe.com/SDR/repo/mcp/CentOS/$releasever/$basearch/current
+  baseurl: http://downloads.linux.hpe.com/SDR/repo/mcp/CentOS/$releasever/$basearch/{{ hwraid_hp_repository_version }}
   gpgcheck: yes
   repo_gpgcheck: no
   gpgkey: http://downloads.linux.hpe.com/SDR/hpePublicKey2048_key1.pub


### PR DESCRIPTION
This should address issues as found in !2

**Fix package names for Debian 8/9**
Add the same packages as are used in RedHat.yml for Debian 8 and 9 where they do exist but not 7. 
* hpacucli isn't present in MCP repository releases anything (likely newer than 10.40), see details at HPE about their [Management Component Pack](http://downloads.linux.hpe.com/SDR/project/mcp/).
* hpssacli was renamed to ssacli

**Introduce a variable that allows overriding the MCP repository version**
Defaulting to current (latest) MCP version is sane for most cases, but there are actual known cases where we do want to specify a certain release because of compatibility issues with either hard- or software.


