### PR TITLE
README: Describe the use of hwraid_hp_repository_version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,11 @@ that can/should be set via parameters to the role. Any variables that are read
 from other roles and/or the global scope (ie. hostvars, group vars, etc.)
 should be mentioned here as well.
 
+- **hwraid_hp_repository_version**: Specify the version of HPE's Management
+  Component Pack (MCP) repository to be used. The default value ``current``
+  includes the latest available version available for the distribution
+  version. Override if you need specific releases of HPE binary-only utilities.
+  For details see `HPE's description about the MCP repository<https://downloads.linux.hpe.com/SDR/project/mcp/>`_.
 
 Dependencies
 =============


### PR DESCRIPTION
##### SUMMARY

* Initial proposal on how to document variables
* Document hwraid_hp_repository_version

##### ISSUE TYPE

 - Docs Pull Request

##### ANSIBLE VERSION

```
$ ansible --version
ansible 2.5.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = [removed]
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.13 (default, Nov 24 2017, 17:33:09) [GCC 6.3.0 20170516]

```


##### ADDITIONAL INFORMATION

If accepted, resolves #2 

There is an open issue with the formatting of the URL to HPE's documentation: pandoc converts it right whereas Github doesn't seem to like it. In the end Galaxy needs to show it correctly.

Please let me know how it should be done.